### PR TITLE
fix: Update generatePages.js to copy Scripts directories

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -164,7 +164,6 @@ tr:nth-child(even) {
     font-weight: bold;
 }
 
-
 /* Console Viewer Styles */
 .script-viewer-container {
     margin-bottom: 40px; /* Space between script viewers */
@@ -228,4 +227,3 @@ tr:nth-child(even) {
 .script-viewer-container .download-link:hover {
     background-color: #2980b9;
 }
-

--- a/generatePages.js
+++ b/generatePages.js
@@ -6,11 +6,11 @@ const outputBase = path.join(__dirname, 'output');
 
 function getIcon(filename) {
   const ext = path.extname(filename).toLowerCase();
-  if (ext === '.pdf') return '📚';
+  if (ext === '.pdf') return '📄';
   if (['.png', '.jpg', '.jpeg', '.gif', '.webp'].includes(ext)) return '🖼️';
   if (['.mp3', '.wav', '.ogg'].includes(ext)) return '🔊';
   if (['.doc', '.docx', '.odt'].includes(ext)) return '📦';
-  if (ext === '.html') return '🌐';
+  if (ext === '.html') return '📝';
   return '📦';
 }
 
@@ -46,6 +46,16 @@ function generatePage(dirPath, relativePath = '') {
       const folderItems = fs.readdirSync(fullItemPath);
       const htmlFiles = folderItems.filter(f => f.toLowerCase().endsWith('.html') && f.toLowerCase() !== 'index.html');
 
+    if (itemName.toLowerCase() === 'scripts') {
+      const destFolder = path.join(outputBase, relItemPath);
+      fs.mkdirSync(destFolder, { recursive: true });
+      fs.cpSync(fullItemPath, destFolder, { recursive: true });
+      console.log(`Copied Scripts directory: ${fullItemPath} to ${destFolder}`); // Added for logging
+      html += `<li>📦 <a href="${itemName}/">${itemName}/ (Scripts)</a></li>
+`; // Link to it in parent index
+      // Continue to next item in forEach loop to prevent further processing of 'Scripts' dir by later else-if blocks
+      return; 
+    }
       if (htmlFiles.length > 0) {
         // 📚 carpeta con materiales HTML (ej: capítulos)
         const destFolder = path.join(outputBase, relItemPath);

--- a/output/Primer_anio/English/1 - Technical English I 2024/Unit 1 - Work - Language Reference/index.html
+++ b/output/Primer_anio/English/1 - Technical English I 2024/Unit 1 - Work - Language Reference/index.html
@@ -19,7 +19,7 @@
 <li>🖼️ <a href="2 - Present_Simple.png">2 - Present_Simple.png</a></li>
 <li>🖼️ <a href="3 - Present_Simple_-_Spelling_Rules.png">3 - Present_Simple_-_Spelling_Rules.png</a></li>
 <li>📦 <a href="4 - Unit 1 - Grammar Practice with Key.docx">4 - Unit 1 - Grammar Practice with Key.docx</a></li>
-<li>📚 <a href="5 - Unit 1 - Language Review.pdf">5 - Unit 1 - Language Review.pdf</a></li>
+<li>📄 <a href="5 - Unit 1 - Language Review.pdf">5 - Unit 1 - Language Review.pdf</a></li>
 <li>📦 <a href="6 - TO BE  - TO HAVE - A-AN - Links.docx">6 - TO BE  - TO HAVE - A-AN - Links.docx</a></li>
   </ul>
 </body>

--- a/output/Primer_anio/English/1 - Technical English I 2024/Unit 1 - Work/Language Reference - Extra Practice/index.html
+++ b/output/Primer_anio/English/1 - Technical English I 2024/Unit 1 - Work/Language Reference - Extra Practice/index.html
@@ -15,7 +15,7 @@
 <body>
   <h1>Primer_anio/English/1 - Technical English I 2024/Unit 1 - Work/Language Reference - Extra Practice</h1>
   <ul>
-<li>📚 <a href="My Grammar Lab Elementary A1-A2 - With Key.pdf">My Grammar Lab Elementary A1-A2 - With Key.pdf</a></li>
+<li>📄 <a href="My Grammar Lab Elementary A1-A2 - With Key.pdf">My Grammar Lab Elementary A1-A2 - With Key.pdf</a></li>
   </ul>
 </body>
 </html>

--- a/output/Primer_anio/English/1 - Technical English I 2024/Unit 1 - Work/Unit 1 - Pronunciation/index.html
+++ b/output/Primer_anio/English/1 - Technical English I 2024/Unit 1 - Work/Unit 1 - Pronunciation/index.html
@@ -31,7 +31,7 @@
 <li>🔊 <a href="BP_A1_CB_062_TkP2_06.mp3">BP_A1_CB_062_TkP2_06.mp3</a></li>
 <li>🔊 <a href="BP_A1_CB_063_TkP2_07.mp3">BP_A1_CB_063_TkP2_07.mp3</a></li>
 <li>🔊 <a href="BP_A1_CB_064_TkP2_08.mp3">BP_A1_CB_064_TkP2_08.mp3</a></li>
-<li>📚 <a href="My Grammar Lab Elementary A1-A2 - With Key.pdf">My Grammar Lab Elementary A1-A2 - With Key.pdf</a></li>
+<li>📄 <a href="My Grammar Lab Elementary A1-A2 - With Key.pdf">My Grammar Lab Elementary A1-A2 - With Key.pdf</a></li>
   </ul>
 </body>
 </html>

--- a/output/Primer_anio/English/1 - Technical English I 2024/Unit 1 - Work/index.html
+++ b/output/Primer_anio/English/1 - Technical English I 2024/Unit 1 - Work/index.html
@@ -15,10 +15,10 @@
 <body>
   <h1>Primer_anio/English/1 - Technical English I 2024/Unit 1 - Work</h1>
   <ul>
-<li>📚 <a href="1 - Unit 1 - Work.pdf">1 - Unit 1 - Work.pdf</a></li>
-<li>📚 <a href="2 - Unit 1 - Work 1.pdf">2 - Unit 1 - Work 1.pdf</a></li>
+<li>📄 <a href="1 - Unit 1 - Work.pdf">1 - Unit 1 - Work.pdf</a></li>
+<li>📄 <a href="2 - Unit 1 - Work 1.pdf">2 - Unit 1 - Work 1.pdf</a></li>
 <li>📦 <a href="2 - Unit 1 – Work 1 - Practice Answers.docx">2 - Unit 1 – Work 1 - Practice Answers.docx</a></li>
-<li>📚 <a href="2 - Unit 1 – Work 1 - Practice Answers.pdf">2 - Unit 1 – Work 1 - Practice Answers.pdf</a></li>
+<li>📄 <a href="2 - Unit 1 – Work 1 - Practice Answers.pdf">2 - Unit 1 – Work 1 - Practice Answers.pdf</a></li>
 <li>📦 <a href="3 - A software development company.docx">3 - A software development company.docx</a></li>
 <li>📦 <a href="4 - Unit 1 - Work - Practice.docx">4 - Unit 1 - Work - Practice.docx</a></li>
 <li>📁 <a href="Language Reference - Extra Practice/index.html">Language Reference - Extra Practice</a></li>

--- a/output/Primer_anio/English/1 - Technical English I 2024/index.html
+++ b/output/Primer_anio/English/1 - Technical English I 2024/index.html
@@ -32,7 +32,7 @@
 <li>🔊 <a href="BP_A1_CB_063_TkP2_07.mp3">BP_A1_CB_063_TkP2_07.mp3</a></li>
 <li>🔊 <a href="BP_A1_CB_064_TkP2_08.mp3">BP_A1_CB_064_TkP2_08.mp3</a></li>
 <li>📦 <a href="Technical English I 2024_.docx">Technical English I 2024_.docx</a></li>
-<li>📚 <a href="Unit 1 - Pronunciation.pdf">Unit 1 - Pronunciation.pdf</a></li>
+<li>📄 <a href="Unit 1 - Pronunciation.pdf">Unit 1 - Pronunciation.pdf</a></li>
 <li>📁 <a href="Unit 1 - Work/index.html">Unit 1 - Work</a></li>
 <li>📁 <a href="Unit 1 - Work - Language Reference/index.html">Unit 1 - Work - Language Reference</a></li>
 <li>📁 <a href="Unit 2 - IT History/index.html">Unit 2 - IT History</a></li>

--- a/output/Segundo_anio/Analisis_matematico/pdfs/index.html
+++ b/output/Segundo_anio/Analisis_matematico/pdfs/index.html
@@ -15,7 +15,7 @@
 <body>
   <h1>Segundo_anio/Analisis_matematico/pdfs</h1>
   <ul>
-<li>📚 <a href="Apuntes Análisis Matemático II.pdf">Apuntes Análisis Matemático II.pdf</a></li>
+<li>📄 <a href="Apuntes Análisis Matemático II.pdf">Apuntes Análisis Matemático II.pdf</a></li>
   </ul>
 </body>
 </html>

--- a/output/Segundo_anio/Analisis_sistema/pdfs/index.html
+++ b/output/Segundo_anio/Analisis_sistema/pdfs/index.html
@@ -15,11 +15,11 @@
 <body>
   <h1>Segundo_anio/Analisis_sistema/pdfs</h1>
   <ul>
-<li>📚 <a href="00_introduccion.pdf">00_introduccion.pdf</a></li>
-<li>📚 <a href="01_introduccion_analisis_y_diseno.pdf">01_introduccion_analisis_y_diseno.pdf</a></li>
-<li>📚 <a href="02_analisis_casos_negocios.pdf">02_analisis_casos_negocios.pdf</a></li>
-<li>📚 <a href="03_administrando_proyectos.pdf">03_administrando_proyectos.pdf</a></li>
-<li>📚 <a href="04_ingenieria_requerimientos.pdf">04_ingenieria_requerimientos.pdf</a></li>
+<li>📄 <a href="00_introduccion.pdf">00_introduccion.pdf</a></li>
+<li>📄 <a href="01_introduccion_analisis_y_diseno.pdf">01_introduccion_analisis_y_diseno.pdf</a></li>
+<li>📄 <a href="02_analisis_casos_negocios.pdf">02_analisis_casos_negocios.pdf</a></li>
+<li>📄 <a href="03_administrando_proyectos.pdf">03_administrando_proyectos.pdf</a></li>
+<li>📄 <a href="04_ingenieria_requerimientos.pdf">04_ingenieria_requerimientos.pdf</a></li>
   </ul>
 </body>
 </html>

--- a/output/Segundo_anio/Bases_de_Datos/videos.html
+++ b/output/Segundo_anio/Bases_de_Datos/videos.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="../../../css/main.css">
+    <link rel="stylesheet" href="../../../css/styles.css">
     <title>Videos sobre SQL</title>
 </head>
 

--- a/output/Segundo_anio/Edi_2/pdfs/index.html
+++ b/output/Segundo_anio/Edi_2/pdfs/index.html
@@ -15,24 +15,24 @@
 <body>
   <h1>Segundo_anio/Edi_2/pdfs</h1>
   <ul>
-<li>📚 <a href="AWTLCL-21.10.pdf">AWTLCL-21.10.pdf</a></li>
-<li>📚 <a href="La línea de comandos de Linux.pdf">La línea de comandos de Linux.pdf</a></li>
-<li>📚 <a href="TLCL-24.11.pdf">TLCL-24.11.pdf</a></li>
-<li>📚 <a href="edi2_00_links.pdf">edi2_00_links.pdf</a></li>
-<li>📚 <a href="edi2_01_debian.pdf">edi2_01_debian.pdf</a></li>
-<li>📚 <a href="edi2_02_cli_01.pdf">edi2_02_cli_01.pdf</a></li>
-<li>📚 <a href="edi2_02_cli_02.pdf">edi2_02_cli_02.pdf</a></li>
-<li>📚 <a href="edi2_02_cli_03.pdf">edi2_02_cli_03.pdf</a></li>
-<li>📚 <a href="edi2_02_cli_04.pdf">edi2_02_cli_04.pdf</a></li>
-<li>📚 <a href="edi2_02_cli_05.pdf">edi2_02_cli_05.pdf</a></li>
-<li>📚 <a href="edi2_03_git_01.pdf">edi2_03_git_01.pdf</a></li>
-<li>📚 <a href="edi2_03_git_02.pdf">edi2_03_git_02.pdf</a></li>
-<li>📚 <a href="edi2_04_network.pdf">edi2_04_network.pdf</a></li>
-<li>📚 <a href="edi2_05_restful_api.pdf">edi2_05_restful_api.pdf</a></li>
-<li>📚 <a href="edi2_06_lc_01.pdf">edi2_06_lc_01.pdf</a></li>
-<li>📚 <a href="edi2_06_lc_02.pdf">edi2_06_lc_02.pdf</a></li>
-<li>📚 <a href="edi2_06_lc_03.pdf">edi2_06_lc_03.pdf</a></li>
-<li>📚 <a href="thelinuxcommandline.pdf">thelinuxcommandline.pdf</a></li>
+<li>📄 <a href="AWTLCL-21.10.pdf">AWTLCL-21.10.pdf</a></li>
+<li>📄 <a href="La línea de comandos de Linux.pdf">La línea de comandos de Linux.pdf</a></li>
+<li>📄 <a href="TLCL-24.11.pdf">TLCL-24.11.pdf</a></li>
+<li>📄 <a href="edi2_00_links.pdf">edi2_00_links.pdf</a></li>
+<li>📄 <a href="edi2_01_debian.pdf">edi2_01_debian.pdf</a></li>
+<li>📄 <a href="edi2_02_cli_01.pdf">edi2_02_cli_01.pdf</a></li>
+<li>📄 <a href="edi2_02_cli_02.pdf">edi2_02_cli_02.pdf</a></li>
+<li>📄 <a href="edi2_02_cli_03.pdf">edi2_02_cli_03.pdf</a></li>
+<li>📄 <a href="edi2_02_cli_04.pdf">edi2_02_cli_04.pdf</a></li>
+<li>📄 <a href="edi2_02_cli_05.pdf">edi2_02_cli_05.pdf</a></li>
+<li>📄 <a href="edi2_03_git_01.pdf">edi2_03_git_01.pdf</a></li>
+<li>📄 <a href="edi2_03_git_02.pdf">edi2_03_git_02.pdf</a></li>
+<li>📄 <a href="edi2_04_network.pdf">edi2_04_network.pdf</a></li>
+<li>📄 <a href="edi2_05_restful_api.pdf">edi2_05_restful_api.pdf</a></li>
+<li>📄 <a href="edi2_06_lc_01.pdf">edi2_06_lc_01.pdf</a></li>
+<li>📄 <a href="edi2_06_lc_02.pdf">edi2_06_lc_02.pdf</a></li>
+<li>📄 <a href="edi2_06_lc_03.pdf">edi2_06_lc_03.pdf</a></li>
+<li>📄 <a href="thelinuxcommandline.pdf">thelinuxcommandline.pdf</a></li>
   </ul>
 </body>
 </html>

--- a/output/Segundo_anio/English/pdfs/index.html
+++ b/output/Segundo_anio/English/pdfs/index.html
@@ -15,23 +15,23 @@
 <body>
   <h1>Segundo_anio/English/pdfs</h1>
   <ul>
-<li>📚 <a href="2_-_Unit_2_-_A_Job_Interview_-_Script.pdf">2_-_Unit_2_-_A_Job_Interview_-_Script.pdf</a></li>
-<li>📚 <a href="Interviews - Extra Practice.pdf">Interviews - Extra Practice.pdf</a></li>
-<li>📚 <a href="List of Irregular Verbs.pdf">List of Irregular Verbs.pdf</a></li>
-<li>📚 <a href="Past Simple - Revision.pdf">Past Simple - Revision.pdf</a></li>
-<li>📚 <a href="Past_Simple_-_Revision.pdf">Past_Simple_-_Revision.pdf</a></li>
-<li>📚 <a href="Past_Simple_Revision_-_Answers.pdf">Past_Simple_Revision_-_Answers.pdf</a></li>
-<li>📚 <a href="Plan_de_Estudio_-_Tecnicatura_Superior_en_Analisis_Desarrollo_y_Programacion_de_Aplicaciones.pdf">Plan_de_Estudio_-_Tecnicatura_Superior_en_Analisis_Desarrollo_y_Programacion_de_Aplicaciones.pdf</a></li>
-<li>📚 <a href="Professional_Profile_-_Jay_Peters.pdf">Professional_Profile_-_Jay_Peters.pdf</a></li>
-<li>📚 <a href="Reducing Costs - Answers.pdf">Reducing Costs - Answers.pdf</a></li>
-<li>📚 <a href="Rubric - English.pdf">Rubric - English.pdf</a></li>
-<li>📚 <a href="Unit 1 - An Introduction to Emails.pdf">Unit 1 - An Introduction to Emails.pdf</a></li>
-<li>📚 <a href="Unit 1 - Audio Files & Videos - Answers.pdf">Unit 1 - Audio Files & Videos - Answers.pdf</a></li>
-<li>📚 <a href="Unit 1 - Jobs.pdf">Unit 1 - Jobs.pdf</a></li>
-<li>📚 <a href="Unit_1_-_Review_-_Answers.pdf">Unit_1_-_Review_-_Answers.pdf</a></li>
-<li>📚 <a href="Unit_1_-_Review_-_Page_94.pdf">Unit_1_-_Review_-_Page_94.pdf</a></li>
-<li>📚 <a href="Unit_2_-_A_Job_Interview.pdf">Unit_2_-_A_Job_Interview.pdf</a></li>
-<li>📚 <a href="Unit_2_-_Job_Interview_-_Answers.pdf">Unit_2_-_Job_Interview_-_Answers.pdf</a></li>
+<li>📄 <a href="2_-_Unit_2_-_A_Job_Interview_-_Script.pdf">2_-_Unit_2_-_A_Job_Interview_-_Script.pdf</a></li>
+<li>📄 <a href="Interviews - Extra Practice.pdf">Interviews - Extra Practice.pdf</a></li>
+<li>📄 <a href="List of Irregular Verbs.pdf">List of Irregular Verbs.pdf</a></li>
+<li>📄 <a href="Past Simple - Revision.pdf">Past Simple - Revision.pdf</a></li>
+<li>📄 <a href="Past_Simple_-_Revision.pdf">Past_Simple_-_Revision.pdf</a></li>
+<li>📄 <a href="Past_Simple_Revision_-_Answers.pdf">Past_Simple_Revision_-_Answers.pdf</a></li>
+<li>📄 <a href="Plan_de_Estudio_-_Tecnicatura_Superior_en_Analisis_Desarrollo_y_Programacion_de_Aplicaciones.pdf">Plan_de_Estudio_-_Tecnicatura_Superior_en_Analisis_Desarrollo_y_Programacion_de_Aplicaciones.pdf</a></li>
+<li>📄 <a href="Professional_Profile_-_Jay_Peters.pdf">Professional_Profile_-_Jay_Peters.pdf</a></li>
+<li>📄 <a href="Reducing Costs - Answers.pdf">Reducing Costs - Answers.pdf</a></li>
+<li>📄 <a href="Rubric - English.pdf">Rubric - English.pdf</a></li>
+<li>📄 <a href="Unit 1 - An Introduction to Emails.pdf">Unit 1 - An Introduction to Emails.pdf</a></li>
+<li>📄 <a href="Unit 1 - Audio Files & Videos - Answers.pdf">Unit 1 - Audio Files & Videos - Answers.pdf</a></li>
+<li>📄 <a href="Unit 1 - Jobs.pdf">Unit 1 - Jobs.pdf</a></li>
+<li>📄 <a href="Unit_1_-_Review_-_Answers.pdf">Unit_1_-_Review_-_Answers.pdf</a></li>
+<li>📄 <a href="Unit_1_-_Review_-_Page_94.pdf">Unit_1_-_Review_-_Page_94.pdf</a></li>
+<li>📄 <a href="Unit_2_-_A_Job_Interview.pdf">Unit_2_-_A_Job_Interview.pdf</a></li>
+<li>📄 <a href="Unit_2_-_Job_Interview_-_Answers.pdf">Unit_2_-_Job_Interview_-_Answers.pdf</a></li>
   </ul>
 </body>
 </html>

--- a/output/Segundo_anio/English/videos/index.html
+++ b/output/Segundo_anio/English/videos/index.html
@@ -15,7 +15,7 @@
 <body>
   <h1>Segundo_anio/English/videos</h1>
   <ul>
-<li>📚 <a href="COMMUNICATION 1 - Video Comprehension.pdf">COMMUNICATION 1 - Video Comprehension.pdf</a></li>
+<li>📄 <a href="COMMUNICATION 1 - Video Comprehension.pdf">COMMUNICATION 1 - Video Comprehension.pdf</a></li>
   </ul>
 </body>
 </html>

--- a/output/Segundo_anio/Poo/fotos_de_pizarron/index.html
+++ b/output/Segundo_anio/Poo/fotos_de_pizarron/index.html
@@ -20,8 +20,8 @@
 <li>🖼️ <a href="03_repaso_de diagnostico_inicial.jpeg">03_repaso_de diagnostico_inicial.jpeg</a></li>
 <li>🖼️ <a href="04_repaso_de diagnostico_inicial.jpeg">04_repaso_de diagnostico_inicial.jpeg</a></li>
 <li>🖼️ <a href="05_repaso_de diagnostico_inicial.jpeg">05_repaso_de diagnostico_inicial.jpeg</a></li>
-<li>📚 <a href="Comenzando con objetos.pdf">Comenzando con objetos.pdf</a></li>
-<li>📚 <a href="instancia.pdf">instancia.pdf</a></li>
+<li>📄 <a href="Comenzando con objetos.pdf">Comenzando con objetos.pdf</a></li>
+<li>📄 <a href="instancia.pdf">instancia.pdf</a></li>
 <li>📁 <a href="juego del truco POO/index.html">juego del truco POO</a></li>
   </ul>
 </body>

--- a/output/Segundo_anio/Poo/pdfs/index.html
+++ b/output/Segundo_anio/Poo/pdfs/index.html
@@ -15,12 +15,12 @@
 <body>
   <h1>Segundo_anio/Poo/pdfs</h1>
   <ul>
-<li>📚 <a href="Clase - 00 - Repaso Inicial II.pdf">Clase - 00 - Repaso Inicial II.pdf</a></li>
-<li>📚 <a href="Clase - 00 - Repaso Inicial.pdf">Clase - 00 - Repaso Inicial.pdf</a></li>
-<li>📚 <a href="Clase - 01.pdf">Clase - 01.pdf</a></li>
-<li>📚 <a href="Clase - 02.pdf">Clase - 02.pdf</a></li>
-<li>📚 <a href="Practico 1 de Repaso.pdf">Practico 1 de Repaso.pdf</a></li>
-<li>📚 <a href="Practico 2 de Repaso.pdf">Practico 2 de Repaso.pdf</a></li>
+<li>📄 <a href="Clase - 00 - Repaso Inicial II.pdf">Clase - 00 - Repaso Inicial II.pdf</a></li>
+<li>📄 <a href="Clase - 00 - Repaso Inicial.pdf">Clase - 00 - Repaso Inicial.pdf</a></li>
+<li>📄 <a href="Clase - 01.pdf">Clase - 01.pdf</a></li>
+<li>📄 <a href="Clase - 02.pdf">Clase - 02.pdf</a></li>
+<li>📄 <a href="Practico 1 de Repaso.pdf">Practico 1 de Repaso.pdf</a></li>
+<li>📄 <a href="Practico 2 de Repaso.pdf">Practico 2 de Repaso.pdf</a></li>
   </ul>
 </body>
 </html>

--- a/output/Segundo_anio/Probabilidad_estadistica/pdfs/index.html
+++ b/output/Segundo_anio/Probabilidad_estadistica/pdfs/index.html
@@ -15,7 +15,7 @@
 <body>
   <h1>Segundo_anio/Probabilidad_estadistica/pdfs</h1>
   <ul>
-<li>📚 <a href="Apuntes Álgebra.pdf">Apuntes Álgebra.pdf</a></li>
+<li>📄 <a href="Apuntes Álgebra.pdf">Apuntes Álgebra.pdf</a></li>
   </ul>
 </body>
 </html>

--- a/output/Segundo_anio/sistemas_operativos/pdf/index.html
+++ b/output/Segundo_anio/sistemas_operativos/pdf/index.html
@@ -15,8 +15,8 @@
 <body>
   <h1>Segundo_anio/sistemas_operativos/pdf</h1>
   <ul>
-<li>📚 <a href="Clase 1 - Sistemas Operativos.pdf">Clase 1 - Sistemas Operativos.pdf</a></li>
-<li>📚 <a href="TP 1 - Introduccion SO.pdf">TP 1 - Introduccion SO.pdf</a></li>
+<li>📄 <a href="Clase 1 - Sistemas Operativos.pdf">Clase 1 - Sistemas Operativos.pdf</a></li>
+<li>📄 <a href="TP 1 - Introduccion SO.pdf">TP 1 - Introduccion SO.pdf</a></li>
   </ul>
 </body>
 </html>

--- a/output/linux/html/bash_error_command_not_found.html
+++ b/output/linux/html/bash_error_command_not_found.html
@@ -11,7 +11,59 @@
       content="ie=edge"
     />
     <title>Solución: Command Not Found</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+      body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        line-height: 1.6;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+        color: #333;
+        background-color: #f9f9f9;
+      }
+      h1,
+      h2,
+      h3 {
+        color: #2c3e50;
+      }
+      h1 {
+        text-align: center;
+        border-bottom: 3px solid #3498db;
+        padding-bottom: 15px;
+        margin-bottom: 30px;
+      }
+      h2 {
+        background-color: #e8f4f8;
+        padding: 10px;
+        border-left: 5px solid #3498db;
+        margin-top: 40px;
+      }
+      code {
+        background-color: #f4f4f4;
+        padding: 2px 4px;
+        border-radius: 4px;
+        font-family: 'Courier New', Courier, monospace;
+      }
+      pre {
+        background-color: #f4f4f4;
+        padding: 10px;
+        border-radius: 4px;
+        overflow-x: auto;
+      }
+      ul {
+        margin: 10px 0;
+        padding-left: 20px;
+      }
+      li {
+        margin-bottom: 10px;
+      }
+      .note {
+        background-color: #fffde7;
+        padding: 15px;
+        border-left: 4px solid #ffd600;
+        margin: 25px 0;
+      }
+    </style>
   </head>
   <body>
     <h1>🛠️ Solución: Command Not Found</h1>

--- a/output/linux/html/bios.html
+++ b/output/linux/html/bios.html
@@ -7,7 +7,120 @@
       content="width=device-width, initial-scale=1.0"
     />
     <title>BIOS vs UEFI vs Legacy: Explicación Completa</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+      body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        line-height: 1.6;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+        color: #333;
+        background-color: #f9f9f9;
+      }
+      h1,
+      h2,
+      h3 {
+        color: #2c3e50;
+      }
+      h1 {
+        text-align: center;
+        border-bottom: 3px solid #3498db;
+        padding-bottom: 15px;
+        margin-bottom: 30px;
+      }
+      h2 {
+        background-color: #e8f4f8;
+        padding: 10px;
+        border-left: 5px solid #3498db;
+        margin-top: 40px;
+      }
+      .tech-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 20px;
+        margin: 30px 0;
+      }
+      .tech-box {
+        flex: 1;
+        min-width: 250px;
+        background: white;
+        border-radius: 8px;
+        padding: 20px;
+        box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
+        border-top: 4px solid;
+      }
+      .bios {
+        border-top-color: #e74c3c;
+      }
+      .uefi {
+        border-top-color: #2ecc71;
+      }
+      .legacy {
+        border-top-color: #f39c12;
+      }
+      .tech-title {
+        font-size: 1.4em;
+        font-weight: bold;
+        margin-bottom: 15px;
+        color: #2c3e50;
+      }
+      .tech-image {
+        text-align: center;
+        margin: 15px 0;
+        font-size: 5em;
+      }
+      .comparison-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 30px 0;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+      }
+      .comparison-table th,
+      .comparison-table td {
+        border: 1px solid #ddd;
+        padding: 12px;
+        text-align: left;
+      }
+      .comparison-table th {
+        background-color: #3498db;
+        color: white;
+      }
+      .comparison-table tr:nth-child(even) {
+        background-color: #f2f2f2;
+      }
+      .pro {
+        color: #27ae60;
+        font-weight: bold;
+      }
+      .con {
+        color: #e74c3c;
+        font-weight: bold;
+      }
+      .note {
+        background-color: #fffde7;
+        padding: 15px;
+        border-left: 4px solid #ffd600;
+        margin: 25px 0;
+      }
+      .boot-process {
+        background-color: #e8f4f8;
+        padding: 20px;
+        border-radius: 8px;
+        margin: 30px 0;
+      }
+      .boot-step {
+        margin-bottom: 15px;
+        position: relative;
+        padding-left: 30px;
+      }
+      .boot-step:before {
+        content: '➔';
+        position: absolute;
+        left: 0;
+        color: #3498db;
+        font-weight: bold;
+      }
+    </style>
   </head>
   <body>
     <h1>¿Qué son BIOS, UEFI y Legacy (CSM)?</h1>

--- a/output/linux/html/creacion_de_instalador_de_manjaro_personalizado.html
+++ b/output/linux/html/creacion_de_instalador_de_manjaro_personalizado.html
@@ -4,7 +4,62 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Crear ISO Personalizada de Manjaro</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            color: #333;
+        }
+        h1 {
+            color: #16A085;
+            border-bottom: 2px solid #16A085;
+            padding-bottom: 10px;
+        }
+        h2 {
+            color: #2C3E50;
+            margin-top: 30px;
+        }
+        code {
+            background-color: #f4f4f4;
+            padding: 2px 5px;
+            border-radius: 3px;
+            font-family: monospace;
+        }
+        pre {
+            background-color: #f4f4f4;
+            padding: 15px;
+            border-radius: 5px;
+            overflow-x: auto;
+            border-left: 4px solid #16A085;
+        }
+        .alert {
+            background-color: #FCF8E3;
+            border-left: 4px solid #F39C12;
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 3px;
+        }
+        .step {
+            background-color: #EBF5FB;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 5px;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        }
+        .step h3 {
+            margin-top: 0;
+            color: #2874A6;
+        }
+        img {
+            max-width: 100%;
+            height: auto;
+            display: block;
+            margin: 20px auto;
+        }
+    </style>
 </head>
 <body>
     <h1>Guía para crear una ISO personalizada de Manjaro</h1>

--- a/output/linux/html/distros.html
+++ b/output/linux/html/distros.html
@@ -4,7 +4,94 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Guía de Distribuciones Linux - Comparativa y Recomendaciones</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            line-height: 1.6;
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 20px;
+            color: #333;
+            background-color: #f9f9f9;
+        }
+        h1, h2, h3 {
+            color: #2c3e50;
+        }
+        h1 {
+            text-align: center;
+            border-bottom: 3px solid #3498db;
+            padding-bottom: 15px;
+            margin-bottom: 30px;
+        }
+        h2 {
+            background-color: #e8f4f8;
+            padding: 10px;
+            border-left: 5px solid #3498db;
+            margin-top: 40px;
+        }
+        .distro-card {
+            background: white;
+            border-radius: 8px;
+            padding: 20px;
+            margin: 20px 0;
+            box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+            border-top: 4px solid;
+        }
+        .manjaro {
+            border-top-color: #2ecc71;
+        }
+        .ubuntu {
+            border-top-color: #e67e22;
+        }
+        .fedora {
+            border-top-color: #3498db;
+        }
+        .mint {
+            border-top-color: #27ae60;
+        }
+        .pros {
+            color: #27ae60;
+            font-weight: bold;
+        }
+        .comparison-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 30px 0;
+            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+        }
+        .comparison-table th, .comparison-table td {
+            border: 1px solid #ddd;
+            padding: 12px;
+            text-align: left;
+        }
+        .comparison-table th {
+            background-color: #3498db;
+            color: white;
+        }
+        .comparison-table tr:nth-child(even) {
+            background-color: #f2f2f2;
+        }
+        .rating {
+            color: #f1c40f;
+            font-weight: bold;
+        }
+        .note {
+            background-color: #fffde7;
+            padding: 15px;
+            border-left: 4px solid #ffd600;
+            margin: 25px 0;
+        }
+        .download-box {
+            background-color: #e8f4f8;
+            padding: 15px;
+            border-radius: 5px;
+            margin: 15px 0;
+        }
+        .stars {
+            color: #f1c40f;
+            font-size: 1.2em;
+        }
+    </style>
 </head>
 <body>
     <h1>Guía para Elegir tu Distribución Linux</h1>

--- a/output/linux/html/error_user_is_not_in_sudoers.html
+++ b/output/linux/html/error_user_is_not_in_sudoers.html
@@ -11,7 +11,59 @@
       content="ie=edge"
     />
     <title>Solución: User is not in the sudoers file</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+      body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        line-height: 1.6;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+        color: #333;
+        background-color: #f9f9f9;
+      }
+      h1,
+      h2,
+      h3 {
+        color: #2c3e50;
+      }
+      h1 {
+        text-align: center;
+        border-bottom: 3px solid #3498db;
+        padding-bottom: 15px;
+        margin-bottom: 30px;
+      }
+      h2 {
+        background-color: #e8f4f8;
+        padding: 10px;
+        border-left: 5px solid #3498db;
+        margin-top: 40px;
+      }
+      code {
+        background-color: #f4f4f4;
+        padding: 2px 4px;
+        border-radius: 4px;
+        font-family: 'Courier New', Courier, monospace;
+      }
+      pre {
+        background-color: #f4f4f4;
+        padding: 10px;
+        border-radius: 4px;
+        overflow-x: auto;
+      }
+      ul {
+        margin: 10px 0;
+        padding-left: 20px;
+      }
+      li {
+        margin-bottom: 10px;
+      }
+      .note {
+        background-color: #fffde7;
+        padding: 15px;
+        border-left: 4px solid #ffd600;
+        margin: 25px 0;
+      }
+    </style>
   </head>
   <body>
     <h1>🛠️ Solución: User is not in the sudoers file</h1>

--- a/output/linux/html/instalacion.html
+++ b/output/linux/html/instalacion.html
@@ -7,7 +7,89 @@
       content="width=device-width, initial-scale=1.0"
     />
     <title>Instalación de Linux en Hardware Real con Ventoy</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+      body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        line-height: 1.7;
+        max-width: 1000px;
+        margin: 0 auto;
+        padding: 25px;
+        color: #333;
+        background-color: #f9f9f9;
+      }
+      h1,
+      h2,
+      h3 {
+        color: #2c3e50;
+      }
+      h1 {
+        text-align: center;
+        border-bottom: 3px solid #4caf50;
+        padding-bottom: 15px;
+        margin-bottom: 30px;
+      }
+      h2 {
+        background-color: #e8f5e9;
+        padding: 12px;
+        border-left: 5px solid #4caf50;
+        margin-top: 40px;
+      }
+      .card {
+        background: white;
+        border-radius: 8px;
+        padding: 20px;
+        margin: 25px 0;
+        box-shadow: 0 3px 10px rgba(0, 0, 0, 0.1);
+        border-top: 4px solid #4caf50;
+      }
+      .warning {
+        background-color: #fff3e0;
+        padding: 15px;
+        border-left: 4px solid #ffa000;
+        margin: 20px 0;
+      }
+      .terminal {
+        background-color: #263238;
+        color: #eeffff;
+        padding: 12px;
+        border-radius: 5px;
+        font-family: 'Courier New', monospace;
+        overflow-x: auto;
+      }
+      .distro-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 25px 0;
+      }
+      .distro-table th,
+      .distro-table td {
+        border: 1px solid #ddd;
+        padding: 12px;
+        text-align: left;
+      }
+      .distro-table th {
+        background-color: #4caf50;
+        color: white;
+      }
+      .step {
+        margin-bottom: 15px;
+        position: relative;
+        padding-left: 30px;
+      }
+      .step:before {
+        content: '➔';
+        position: absolute;
+        left: 0;
+        color: #4caf50;
+        font-weight: bold;
+      }
+      .note {
+        background-color: #e3f2fd;
+        padding: 15px;
+        border-left: 4px solid #2196f3;
+        margin: 20px 0;
+      }
+    </style>
   </head>
   <body>
     <h1>Guía Completa: Instalación de Linux en Hardware Real con Ventoy</h1>

--- a/output/linux/html/metodo_recuperacion.html
+++ b/output/linux/html/metodo_recuperacion.html
@@ -11,7 +11,59 @@
       content="ie=edge"
     />
     <title>Método de Recuperación</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+      body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        line-height: 1.6;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+        color: #333;
+        background-color: #f9f9f9;
+      }
+      h1,
+      h2,
+      h3 {
+        color: #2c3e50;
+      }
+      h1 {
+        text-align: center;
+        border-bottom: 3px solid #3498db;
+        padding-bottom: 15px;
+        margin-bottom: 30px;
+      }
+      h2 {
+        background-color: #e8f4f8;
+        padding: 10px;
+        border-left: 5px solid #3498db;
+        margin-top: 40px;
+      }
+      code {
+        background-color: #f4f4f4;
+        padding: 2px 4px;
+        border-radius: 4px;
+        font-family: 'Courier New', Courier, monospace;
+      }
+      pre {
+        background-color: #f4f4f4;
+        padding: 10px;
+        border-radius: 4px;
+        overflow-x: auto;
+      }
+      ul {
+        margin: 10px 0;
+        padding-left: 20px;
+      }
+      li {
+        margin-bottom: 10px;
+      }
+      .note {
+        background-color: #fffde7;
+        padding: 15px;
+        border-left: 4px solid #ffd600;
+        margin: 25px 0;
+      }
+    </style>
   </head>
   <body>
     <h1>🛠️ Método de Recuperación</h1>

--- a/output/linux/html/preparacion.html
+++ b/output/linux/html/preparacion.html
@@ -7,7 +7,68 @@
       content="width=device-width, initial-scale=1.0"
     />
     <title>Guía Completa de Ventoy para Windows y Linux</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        line-height: 1.6;
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 20px;
+        color: #333;
+      }
+      h1,
+      h2,
+      h3 {
+        color: #2c3e50;
+      }
+      h1 {
+        border-bottom: 2px solid #3498db;
+        padding-bottom: 10px;
+      }
+      h2 {
+        background-color: #f8f9fa;
+        padding: 8px;
+        border-left: 4px solid #3498db;
+      }
+      code {
+        background-color: #f0f0f0;
+        padding: 2px 5px;
+        border-radius: 3px;
+        font-family: Consolas, monospace;
+      }
+      pre {
+        background-color: #f8f8f8;
+        padding: 10px;
+        border-radius: 5px;
+        overflow-x: auto;
+      }
+      .note {
+        background-color: #e7f5fe;
+        border-left: 4px solid #3498db;
+        padding: 10px;
+        margin: 10px 0;
+      }
+      .warning {
+        background-color: #fff3cd;
+        border-left: 4px solid #ffc107;
+        padding: 10px;
+        margin: 10px 0;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 20px 0;
+      }
+      th,
+      td {
+        border: 1px solid #ddd;
+        padding: 8px;
+        text-align: left;
+      }
+      th {
+        background-color: #f2f2f2;
+      }
+    </style>
   </head>
   <body>
     <h1>

--- a/output/linux/html/recomendacion.html
+++ b/output/linux/html/recomendacion.html
@@ -4,7 +4,103 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Por Qué Manjaro Es Mi Distribución Linux Definitiva</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            line-height: 1.7;
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 25px;
+            color: #333;
+            background-color: #f9f9f9;
+        }
+        h1, h2, h3 {
+            color: #2c3e50;
+        }
+        h1 {
+            text-align: center;
+            border-bottom: 3px solid #35a79c;
+            padding-bottom: 15px;
+            margin-bottom: 30px;
+        }
+        h2 {
+            background-color: #e0f7fa;
+            padding: 12px;
+            border-left: 5px solid #35a79c;
+            margin-top: 40px;
+        }
+        .testimonial {
+            background-color: #e8f4f8;
+            padding: 20px;
+            border-radius: 8px;
+            margin: 25px 0;
+            border-left: 4px solid #35a79c;
+        }
+        .feature {
+            background: white;
+            border-radius: 8px;
+            padding: 20px;
+            margin: 20px 0;
+            box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+            border-top: 4px solid #35a79c;
+        }
+        .pros-cons {
+            display: flex;
+            gap: 20px;
+            margin: 25px 0;
+        }
+        .pros, .cons {
+            flex: 1;
+            padding: 15px;
+            border-radius: 8px;
+        }
+        .pros {
+            background-color: #e8f5e9;
+            border-left: 4px solid #4caf50;
+        }
+        .cons {
+            background-color: #ffebee;
+            border-left: 4px solid #f44336;
+        }
+        .journey {
+            background-color: #fff3e0;
+            padding: 20px;
+            border-radius: 8px;
+            margin: 25px 0;
+        }
+        .journey-step {
+            margin-bottom: 15px;
+            position: relative;
+            padding-left: 30px;
+        }
+        .journey-step:before {
+            content: "→";
+            position: absolute;
+            left: 0;
+            color: #ff9800;
+            font-weight: bold;
+        }
+        .note {
+            background-color: #fffde7;
+            padding: 15px;
+            border-left: 4px solid #ffd600;
+            margin: 25px 0;
+        }
+        a {
+            color: #1e88e5;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .manjaro-logo {
+            text-align: center;
+            margin: 20px 0;
+            font-size: 3em;
+            color: #35a79c;
+        }
+    </style>
 </head>
 <body>
     <div class="manjaro-logo">⎈ Manjaro Linux</div>

--- a/output/linux/html/ventoy.html
+++ b/output/linux/html/ventoy.html
@@ -7,7 +7,104 @@
       content="width=device-width, initial-scale=1.0"
     />
     <title>Ventajas de Ventoy vs. Otras Herramientas</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+      body {
+        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        line-height: 1.6;
+        max-width: 1000px;
+        margin: 0 auto;
+        padding: 20px;
+        color: #333;
+      }
+      h1,
+      h2,
+      h3 {
+        color: #2c3e50;
+      }
+      h1 {
+        border-bottom: 3px solid #3498db;
+        padding-bottom: 10px;
+        text-align: center;
+      }
+      h2 {
+        background-color: #f8f9fa;
+        padding: 10px;
+        border-left: 5px solid #3498db;
+        margin-top: 30px;
+      }
+      h3 {
+        color: #2980b9;
+        border-bottom: 1px dashed #ccc;
+        padding-bottom: 5px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 20px 0;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+      }
+      th,
+      td {
+        border: 1px solid #ddd;
+        padding: 12px;
+        text-align: left;
+      }
+      th {
+        background-color: #3498db;
+        color: white;
+      }
+      tr:nth-child(even) {
+        background-color: #f2f2f2;
+      }
+      .feature {
+        background-color: #e8f4f8;
+        padding: 15px;
+        border-radius: 5px;
+        margin: 15px 0;
+      }
+      .pros {
+        color: #27ae60;
+        font-weight: bold;
+      }
+      .cons {
+        color: #e74c3c;
+        font-weight: bold;
+      }
+      .note {
+        background-color: #fffde7;
+        padding: 15px;
+        border-left: 4px solid #ffd600;
+        margin: 20px 0;
+      }
+      .comparison-table {
+        overflow-x: auto;
+      }
+      .tech-box {
+        background-color: #f5f5f5;
+        border: 1px solid #ddd;
+        padding: 20px;
+        margin: 25px 0;
+        border-radius: 5px;
+      }
+      .tech-header {
+        color: #2c3e50;
+        font-size: 1.3em;
+        margin-bottom: 15px;
+        font-weight: bold;
+      }
+      .tech-feature {
+        margin-bottom: 10px;
+        padding-left: 15px;
+        position: relative;
+      }
+      .tech-feature:before {
+        content: '•';
+        position: absolute;
+        left: 0;
+        color: #3498db;
+        font-weight: bold;
+      }
+    </style>
   </head>
   <body>
     <h1>Ventajas de Ventoy frente a otras herramientas de USB booteable</h1>

--- a/output/linux/html/visudo.html
+++ b/output/linux/html/visudo.html
@@ -11,7 +11,44 @@
       content="ie=edge"
     />
     <title>Uso de visudo</title>
-    <link rel="stylesheet" href="../../../css/main.css">
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        line-height: 1.6;
+        margin: 0;
+        padding: 20px;
+        background-color: #f9f9f9;
+        color: #333;
+      }
+      h1,
+      h2,
+      h3 {
+        color: #222;
+      }
+      h1 {
+        text-align: center;
+        margin-bottom: 20px;
+      }
+      code {
+        background-color: #f4f4f4;
+        padding: 2px 4px;
+        border-radius: 4px;
+        font-family: 'Courier New', Courier, monospace;
+      }
+      pre {
+        background-color: #f4f4f4;
+        padding: 10px;
+        border-radius: 4px;
+        overflow-x: auto;
+      }
+      ul {
+        margin: 10px 0;
+        padding-left: 20px;
+      }
+      li {
+        margin-bottom: 10px;
+      }
+    </style>
   </head>
   <body>
     <h1>🛠️ Uso de visudo</h1>


### PR DESCRIPTION
I modified `generatePages.js` to ensure that directories named 'Scripts' (e.g., containing .sh files for viewers) are recursively copied from the 'materias' directory to the 'output' directory during page generation.

This change allows linked content within these 'Scripts' directories, such as files for download links in script viewers, to be available in the generated output site.

I also added a link to the copied 'Scripts' folder in its parent's generated index.html for better navigation.